### PR TITLE
supports external schema files based on filename

### DIFF
--- a/src/getSchemaProps.js
+++ b/src/getSchemaProps.js
@@ -26,10 +26,27 @@ const getXsiNamespacePrefixes = (attributes) => {
 
 const hasEvenIndex = (unused, index) => index % 2;
 
-const getSchemaProps = textEditor =>
+const getSchemaPropsFromConfig = (config, fileName) => {
+  if (config.rules) {
+    return config.rules
+    .filter(({testPathRegex}) => {
+      if (testPathRegex) {
+        const re = new RegExp(testPathRegex);
+        return re.test(fileName);
+      } else {
+        return false;
+      }
+    })
+    .map(({outcomeSchemaProps}) => outcomeSchemaProps);
+  } else {
+    return [];
+  }
+};
+
+const getSchemaProps = (textEditor, config) =>
   new Promise((resolve) => {
     const messages = [];
-    const schemaProps = [];
+    const schemaProps = getSchemaPropsFromConfig(config, textEditor.getFileName());
     const xsdSchemaPaths = [];
     const saxParser = sax.parser(true);
 

--- a/src/main.js
+++ b/src/main.js
@@ -101,7 +101,7 @@ module.exports = {
       lint(textEditor) {
         return Promise.all([
           serverProcessInstance.ensureIsReady(localConfig),
-          getSchemaProps(textEditor),
+          getSchemaProps(textEditor, localConfig),
         ])
         .then(validate(textEditor, localConfig))
         .catch(addErrorNotification);
@@ -127,7 +127,7 @@ module.exports = {
 
         return Promise.all([
           serverProcessInstance.ensureIsReady(localConfig),
-          getSchemaProps(options.editor),
+          getSchemaProps(options.editor, localConfig),
         ])
         .then(suggest(options, localConfig))
         .catch(addErrorNotification);


### PR DESCRIPTION
(posted as _Work in Progress_ to get feedback on the approach)

This fixes #26 by reading a new entry in `~/.atom/config.cson`:

``` cson
"linter-autocomplete-jing":
  rules: [
    {
      testPathRegex: ".cnxml$"
      outcomeSchemaProps: {
        lang: "rng"
        path: "/path/to/cnxml-jing.rng"
      }
    }
```

Additionally, if your file extension is not recognized by Atom as an XML file then you will need to add an entry similar to:

``` cson
"*":
  core:
    customFileTypes:
      "text.xml": [ "index.cnxml" ]
```
# Screenshot

![](https://cloud.githubusercontent.com/assets/253202/19170365/1adcc7f0-8be6-11e6-8279-ef02d90c4479.gif)
# Install Instructions

``` sh
git clone https://github.com/philschatz/linter-autocomplete-jing`
cd linter-autocomplete-jing
git checkout external-schema-file
apm link .
npm run-script watch
# restart atom
```
# TODO
- [ ] clean up the JavaScript code
- [ ] discuss how to obtain the namespace of the root element (to support the `rootNs:` option discussed)
